### PR TITLE
fix java.security.AccessControlException

### DIFF
--- a/src/main/java/com/overops/plugins/sonar/OverOpsPlugin.java
+++ b/src/main/java/com/overops/plugins/sonar/OverOpsPlugin.java
@@ -1,22 +1,3 @@
-/*
- * Example Plugin for SonarQube
- * Copyright (C) 2009-2016 SonarSource SA
- * mailto:contact AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 package com.overops.plugins.sonar;
 
 import com.overops.plugins.sonar.measures.OverOpsEventsStatistic;
@@ -25,7 +6,6 @@ import com.overops.plugins.sonar.measures.OverOpsMetrics;
 import com.overops.plugins.sonar.measures.OverOpsQualityGateStat;
 import com.overops.plugins.sonar.rules.RuleDefinitionImplementation;
 import com.overops.plugins.sonar.settings.OverOpsProperties;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 import com.takipi.api.client.RemoteApiClient;
 import com.takipi.api.client.data.view.SummarizedView;
 import com.takipi.api.client.functions.input.ReliabilityReportInput;
@@ -50,6 +30,7 @@ import org.sonar.api.utils.log.Loggers;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -310,7 +291,7 @@ public class OverOpsPlugin implements Plugin {
 
 		adminUserName = config.get(OverOpsProperties.SONAR_OVEROPS_USER_NAME).orElse("admin");
 		adminUserPassword = config.get(OverOpsProperties.SONAR_OVEROPS_USER_PASSWORD).orElse("admin");
-		AUTH_DATA = Base64.encode(new StringBuilder()
+		AUTH_DATA = Base64.getEncoder().encodeToString(new StringBuilder()
 				.append(adminUserName).append(":").append(adminUserPassword)
 				.toString().getBytes());
 


### PR DESCRIPTION
Use java.util.Base64; fixes security exception found in ce.log. I believe this was preventing the background task from completing successfully.

```
2019.11.26 15:25:26 INFO  ce[][o.s.c.c.CePluginRepository] Load plugins
2019.11.26 15:25:27 ERROR ce[][o.s.ce.app.CeServer] Compute Engine startup failed
java.lang.IllegalStateException: Fail to load plugin OverOps Plugin for SonarQube 6.7.x LTS [overops]
	at org.sonar.server.plugins.ServerExtensionInstaller.installExtensions(ServerExtensionInstaller.java:88)
	at org.sonar.ce.container.ComputeEngineContainerImpl.startLevel4(ComputeEngineContainerImpl.java:230)
	at org.sonar.ce.container.ComputeEngineContainerImpl.start(ComputeEngineContainerImpl.java:196)
	at org.sonar.ce.ComputeEngineImpl.startup(ComputeEngineImpl.java:45)
	at org.sonar.ce.app.CeServer$CeMainThread.attemptStartup(CeServer.java:163)
	at org.sonar.ce.app.CeServer$CeMainThread.run(CeServer.java:141)
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.org.apache.xerces.internal.impl.dv.util")
	at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:895)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
	at java.base/java.lang.SecurityManager.checkPackageAccess(SecurityManager.java:1238)
	at java.base/java.lang.ClassLoader$1.run(ClassLoader.java:690)
	at java.base/java.lang.ClassLoader$1.run(ClassLoader.java:688)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.lang.ClassLoader.checkPackageAccess(ClassLoader.java:688)
	at com.overops.plugins.sonar.OverOpsPlugin.getConfigProperties(OverOpsPlugin.java:294)
	at com.overops.plugins.sonar.OverOpsPlugin.getOverOpsDataAndCreateStatistic(OverOpsPlugin.java:95)
	at com.overops.plugins.sonar.OverOpsPlugin.define(OverOpsPlugin.java:79)
	at org.sonar.server.plugins.ServerExtensionInstaller.installExtensions(ServerExtensionInstaller.java:78)
	... 5 common frames omitted
2019.11.26 15:25:27 INFO  ce[][o.s.p.ProcessEntryPoint] Hard stopping process
```